### PR TITLE
Changed old style function applications to 'M:F()'

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,5 +8,5 @@
   {rabbit_common, ".*",
     {git, "git://github.com/muxspace/rabbit_common.git", "master"}},
   {'bson', ".*",
-    {git, "https://github.com/muxspace/bson_erlang.git", "master"}}
+    {git, "https://github.com/mongodb/bson-erlang.git", "master"}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -8,5 +8,5 @@
   {rabbit_common, ".*",
     {git, "git://github.com/muxspace/rabbit_common.git", "master"}},
   {'bson', ".*",
-    {git, "https://github.com/mongodb/bson-erlang.git", "master"}}
+    {git, "https://github.com/superbobry/bson-erlang.git", "master"}}
 ]}.

--- a/src/farm_tools.erl
+++ b/src/farm_tools.erl
@@ -1,11 +1,11 @@
 %% Copyright 2011 Brian Lee Yung Rowe
-%% 
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%   http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
 
 -module(farm_tools).
 -include("bunny_farm.hrl").
--export([decode_properties/1, 
+-export([decode_properties/1,
   decode_payload/1, decode_payload/2,
   encode_payload/1, encode_payload/2]).
 -export([to_list/1, atomize/1, atomize/2, listify/1, listify/2]).
@@ -24,7 +24,7 @@
          to_amqp_props/1,
          to_basic_consume/1,
          is_rpc/1,
-         reply_to/1, reply_to/2, 
+         reply_to/1, reply_to/2,
          content_type/1, content_type/2,
          encoding/1,
          correlation_id/1 ]).
@@ -38,12 +38,12 @@ decode_properties(#amqp_msg{props=Properties}) ->
 
 decode_payload(#amqp_msg{payload=Payload}=Content) ->
   decode_payload(content_type(Content), Payload);
-  
+
 decode_payload(Payload) -> decode_payload(bson, Payload).
 
 decode_payload(none, Payload) -> Payload;
 decode_payload(<<"application/octet-stream">>, Payload) -> Payload;
-decode_payload({_E,M,F}, Payload) -> {M,F}(Payload);
+decode_payload({_E,M,F}, Payload) -> M:F(Payload);
 
 decode_payload(<<"application/x-erlang">>, Payload) ->
   decode_payload(erlang, Payload);
@@ -63,7 +63,7 @@ encode_payload(Payload) -> encode_payload(bson, Payload).
 
 encode_payload(none, Payload) -> Payload;
 encode_payload(<<"application/octet-stream">>, Payload) -> Payload;
-encode_payload({_E,M,F}, Payload) -> {M,F}(Payload);
+encode_payload({_E,M,F}, Payload) -> M:F(Payload);
 
 encode_payload(<<"application/x-erlang">>, Payload) ->
   encode_payload(erlang, Payload);
@@ -97,9 +97,9 @@ listify(List) when is_list(List) ->
 listify(List, Sep) when is_list(List) ->
   [H|T] = List,
   lists:foldl(fun(X,Y) -> Y ++ Sep ++ to_list(X) end, to_list(H), T).
-  
+
 %% Convenience function to convert values to binary strings. Useful for
-%% creating binary names for exchanges or routing keys. Not recommended 
+%% creating binary names for exchanges or routing keys. Not recommended
 %% for payloads.
 binarize(Binary) when is_binary(Binary) -> Binary;
 
@@ -118,7 +118,7 @@ to_exchange_declare(Props) ->
   %% This is a safety in case certain arguments aren't set elsewhere
   Defaults = [ {ticket,0}, {arguments,[]} ],
   Enriched = lists:merge(Props, Defaults),
-  list_to_tuple(['exchange.declare'|[proplists:get_value(X,Enriched,false) || 
+  list_to_tuple(['exchange.declare'|[proplists:get_value(X,Enriched,false) ||
     X <- record_info(fields,'exchange.declare')]]).
 
 %% Converts a tuple list of values to a queue.declare record
@@ -127,7 +127,7 @@ to_queue_declare(Props) ->
   %% This is a safety in case certain arguments aren't set elsewhere
   Defaults = [ {ticket,0}, {arguments,[]} ],
   Enriched = lists:merge(Props, Defaults),
-  list_to_tuple(['queue.declare'|[proplists:get_value(X,Enriched,false) || 
+  list_to_tuple(['queue.declare'|[proplists:get_value(X,Enriched,false) ||
     X <- record_info(fields,'queue.declare')]]).
 
 %% Converts a tuple list to a basic.consume record
@@ -135,13 +135,13 @@ to_queue_declare(Props) ->
 to_basic_consume(Props) ->
   Defaults = [ {ticket,0}, {arguments,[]}, {consumer_tag,<<"">>} ],
   Enriched = lists:merge(Props, Defaults),
-  list_to_tuple(['basic.consume'|[proplists:get_value(X,Enriched,false) || 
+  list_to_tuple(['basic.consume'|[proplists:get_value(X,Enriched,false) ||
     X <- record_info(fields,'basic.consume')]]).
 
 %% Converts a tuple list of values to amqp_msg properties (P_basic)
 -spec to_amqp_props([{atom(), term()}]) -> #'P_basic'{}.
 to_amqp_props(Props) ->
-  list_to_tuple(['P_basic'|[proplists:get_value(X,Props) || 
+  list_to_tuple(['P_basic'|[proplists:get_value(X,Props) ||
     X <- record_info(fields,'P_basic')]]).
 
 is_rpc(#amqp_msg{props=Props}) ->

--- a/src/farm_tools.erl
+++ b/src/farm_tools.erl
@@ -53,7 +53,7 @@ decode_payload(<<"application/bson">>, Payload) ->
 decode_payload(bson, Payload) ->
   try
     {Doc,_Bin} = bson_binary:get_document(Payload),
-    bson:reflate(Doc)
+    bson:fields(Doc)
   catch
     error:{badmatch,_} -> decode_payload(erlang, Payload);
     error:function_clause -> decode_payload(erlang, Payload)


### PR DESCRIPTION
This way it doesn't break 'dialyzer', which otherwise fails with `apply_op_not_a_variable`. See [*] for details:

  [*] http://erlang.org/pipermail/erlang-questions/2011-October/061600.html
